### PR TITLE
fixing typo in example

### DIFF
--- a/examples/ina260_simpletest.py
+++ b/examples/ina260_simpletest.py
@@ -5,6 +5,6 @@ import adafruit_ina260
 i2c = board.I2C()
 ina260 = adafruit_ina260.INA260(i2c)
 while True:
-    print("Current: %.2f mV Voltage: %.2f V Power:%.2f mW"
+    print("Current: %.2f mA Voltage: %.2f V Power:%.2f mW"
           %(ina260.current, ina260.voltage, ina260.power))
     time.sleep(1)


### PR DESCRIPTION
current is measured in amps, not volts.